### PR TITLE
Revert "read locale config for faker"

### DIFF
--- a/src/lib/Generator.ts
+++ b/src/lib/Generator.ts
@@ -24,16 +24,9 @@ export class Generator {
         let db = this.DB
         let object = this.object
 
-        let re = /(^[a-z_A-Z]*)/   // en_US
-        let matches = re.exec(cfg.locale)
+        let re = /(^[a-zA-Z.]*)/   // aZ.aZ
+        let matches = re.exec(cfg.faker)
         let strFn
-        if (matches && matches.length === 2) {
-            strFn = 'faker.' + cfg.locale
-            eval(strFn)
-        }
-
-        re = /(^[a-zA-Z.]*)/   // aZ.aZ
-        matches = re.exec(cfg.faker)
         if (matches && matches.length === 2) {
             strFn = 'faker.' + cfg.faker
         }


### PR DESCRIPTION
Reverts danibram/mocker-data-generator#32

Sorry @sleicht but is not working for me, i just fixed doing this:

```

faker = require('faker/locale/en')

        if (cfg.locale) {
            re = /(^[a-z_A-Z]*)/   // en_US
            matches = re.exec(cfg.locale)

            if (matches && matches.length === 2) {
                faker = require('faker/locale/' + cfg.locale)
            }
        }
```

Im going to write in the docs, finish the tests and update the version, thank you anyway!