### PR TITLE
Add synchronous build method

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ mocker()
         },
         err => console.error(err)
     )
+
+// Synchronously
+
+// This returns an object
+// {
+//      user:[array of users],
+//      group: [array of groups],
+//      conditionalField: [array of conditionalFields]
+// }
+var data = mocker()
+    .schema('user', user, 2)
+    .schema('group', group, 2)
+    .schema('conditionalField', conditionalField, 2)
+    .buildSync()
+
+console.log(util.inspect(data, { depth: 10 }))
 ```
 
 ## Documentation
@@ -144,6 +160,7 @@ Data generation goes with model based composed by generators, the generators can
 *   **_reset()_**: Clean the internal DB.
 *   **_restart()_**: Clean the internal DB and all the schemas inside.
 *   **_build(callback)_**: This methods start to produce the data and wrap it to the callback function, the callback funtion have 2 parameters, error and data generated.
+-   **_buildSync()_**: Synchronous version of `build(callback)`. Returns generated data or throws an error.
 
 ### Schema definition
 

--- a/src/lib/tests/Mocker.build.spec.ts
+++ b/src/lib/tests/Mocker.build.spec.ts
@@ -152,3 +152,38 @@ test('Should build with Promised old style', async (t) => {
         .build()
         .then((db) => t.deepEqual(db, result))
 })
+
+test('Should build synchronously', (t) => {
+    let result = {
+        users: [
+            {
+                hello: 'world'
+            }
+        ]
+    }
+    let mock = new Mocker()
+    let db = mock.schema('users', { hello: { static: 'world' } }, 1).buildSync()
+
+    t.deepEqual(db, result)
+})
+
+test('Should throw synchronously', (t) => {
+    let result = {
+        users: [
+            {
+                hello: 'world'
+            }
+        ]
+    }
+    let mock = new Mocker()
+    const error = t.throws(() =>
+        mock
+            .schema('users', { hello: { faker: 'worldrqwerqw' } }, 1)
+            .buildSync()
+    )
+
+    t.is(
+        error.message,
+        'Schema: "users" Error: "faker" This faker method doesnt exists \'worldrqwerqw\'.'
+    )
+})


### PR DESCRIPTION
Add a new `buildSync` method alongside the existing `build` method to allow the generator to be used where synchronous flow is required.

This is a simple non-breaking surface-level change. The library does not currently include any internal async logic. The async behavior of the `build` method is designed to avoid an unwanted breaking interface change in the future if async logic is added (discussed [here](https://github.com/danibram/mocker-data-generator/issues/100)). If async generators are added in the future, I suggest that they be excluded from the set of generators available for use when calling `buildSync` - this could be achieved cleanly in typescript by giving the `Mocker` class a generic `Schema` type that is referenced in conditional types on the `build` and `buildSync` methods. This would also require adding strict type inference to the schema interface, but doing so could have the added benefit of returning non-opaque typed data.